### PR TITLE
Fixing a few small typos...

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Clone this repository to get the notebooks and data:
 With Anaconda, install the following packages with these commands:
 
 ```
-conda install statsmodels.api
-conda install patry
+conda install statsmodels
+conda install patsy
 conda install matplotlib
 conda install seaborn
 conda install pip


### PR DESCRIPTION
patsy was spelled incorrectly, and you only need install statsmodels to the get the api module.