### PR TITLE
Adding lifelines install and graphviz comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,5 +13,8 @@ conda install matplotlib
 conda install seaborn
 conda install scikit-learn
 conda install pip
+# For graphviz to work, you will need the executable installed on your system.
+# On a mac, you can simply run `brew install graphviz` if you have Homebrew installed.
 pip install graphviz
+pip install lifelines
 ```


### PR DESCRIPTION
The lifelines library is missing from the list of packages to install. In addition, graphviz will only work if you have the executable installed on your system, so I added a comment on the need to install that as well.